### PR TITLE
Fix `Strike Get` help message

### DIFF
--- a/flamingoservice/strike.go
+++ b/flamingoservice/strike.go
@@ -241,7 +241,7 @@ func (strikeClient *StrikeClient) Help(session *discordgo.Session, channelID str
 				&discordgo.MessageEmbedField{
 					Name: "get",
 					Value: "Retrieves the strike count of mentioned users. \n" +
-						"Usage: ```~strike @user1 @user2 ...```",
+						"Usage: ```~strike get @user1 @user2 ...```",
 				},
 				&discordgo.MessageEmbedField{
 					Name:  "help",


### PR DESCRIPTION
In the `help` command for `Strike`, there is a discrepancy between `strike get` actual syntax and the syntax stated through the help message. This pull request fixes that discrepancy.